### PR TITLE
Update link to lotus miner filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 BitScreen is a tool for Filecoin storage providers. It’s purpose is to allow storage providers to prevent a particular file (or files) from being stored or retrieved (or both). Storage providers may want to do this if a particular file contains material that is illegal, or violates the node operators' content policy -- that is, if the file contains content that the storage providers does not want to host or does not want to serve. By adding a CID to BitScreen, a storage providers can decline to host or allow retrieval of files.
 
-BitScreen works by comparing a Payload ContentID (CID) against a selected list of known CIDs. Payload CIDs found in the BitScreen list will activate the Filecoin [DealMaking filter](https://github.com/filecoin-project/filecoin-docs/blob/master/docs/mine/lotus/miner-configuration.md#dealmaking-section) and will be filtered out from deals. Storage providerss may use this functionality to enforce their content policy, where appropriate, as well as satisfy other legal or compliance requirements.
+BitScreen works by comparing a Payload ContentID (CID) against a selected list of known CIDs. Payload CIDs found in the BitScreen list will activate the Filecoin [DealMaking filter](https://lotus.filecoin.io/docs/storage-providers/config/#dealmaking-section) and will be filtered out from deals. Storage providerss may use this functionality to enforce their content policy, where appropriate, as well as satisfy other legal or compliance requirements.
 
 *See also*: [Content Policy Guide for Filecoin Node Operators](https://github.com/Murmuration-Labs/filecoin-node-operator-kit/blob/main/Content-Policy-Guide.md)
 
@@ -16,7 +16,7 @@ Storage providers may add a CID manually to their local BitScreen list by adding
 
 BitScreen then acts as an external program which provides input to the DealMaking filter function in Filecoin’s Lotus Miner. Node operators can use this input to block storage and retrieval deals for known CIDs. As a result, clients seeking to store a file with a filtered CID will not be able to form a storage deal with the storage providers. Similarly, clients seeking to retrieve a file already stored by the storage providers, and that has a filtered CID, will not be able to retrieve the file.
 
-*See also*: [Filecoin Lotus Miner Filter](https://github.com/filecoin-project/filecoin-docs/blob/master/docs/mine/lotus/miner-configuration.md#dealmaking-section)
+*See also*: [Filecoin Lotus Miner Filter](https://lotus.filecoin.io/docs/storage-providers/config/#dealmaking-section)
 
 ## Upcoming Features
 


### PR DESCRIPTION
This PR updates the link to the lotus miner filter, since the lotus docs were moved out to their own site. cc @tim-murmuration